### PR TITLE
chore: Add build step to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,12 @@ Install the dependencies by running yarn (only tested with yarn v1) in the root 
 yarn
 ```
 
+Then build the packages:
+
+```bash
+lerna run build
+```
+
 Then serve the ui web app:
 
 ```bash


### PR DESCRIPTION
When following the contributing steps, serving the UI Web app fails as it can't resolve the @guijs modules. These packages need to be built first. This PR adds the step of running `learn run build` which will run the build scripts in each package.