### PR TITLE
feat(tauri): make bundle smaller

### DIFF
--- a/packages/@guijs/tauri-app/src-tauri/Cargo.toml
+++ b/packages/@guijs/tauri-app/src-tauri/Cargo.toml
@@ -40,3 +40,11 @@ no-server = [ "tauri/no-server" ]
 [[bin]]
 name = "guijs"
 path = "src/main.rs"
+
+[profile.release]
+panic = "abort"
+codegen-units = 1
+lto = true
+incremental = false
+opt-level = "z"
+


### PR DESCRIPTION
This merely adds our vetted release flags that use a single thread and a couple other optimizations (so the bundler is unfortunately a LITTLE slower) but this does create a smaller bundle and helps save the planet one download at a time.

Here is a little more information about that:

https://github.com/tauri-apps/tauri/wiki/13.-Bundler