### PR TITLE
fix: error message wording

### DIFF
--- a/packages/@guijs/frontend-tauri/src/components/NodeWrongVersion.vue
+++ b/packages/@guijs/frontend-tauri/src/components/NodeWrongVersion.vue
@@ -26,7 +26,7 @@ export default {
 
 <template>
   <Error
-    :label="`Node.js v${requiredVersion} or more is required, found v${foundVersion}`"
+    :label="`Node.js v${requiredVersion} or later is required, found v${foundVersion}`"
   >
     Please update Node at <a
       href="https://nodejs.org"


### PR DESCRIPTION
Just a little wording fix for the node version error screen, since software versions are technically not compared using "more" but "later" :)

see also https://english.stackexchange.com/questions/112257/above-or-later-when-referencing-a-range-of-versions-of-software